### PR TITLE
Timing Issue Fix

### DIFF
--- a/features/200_Correlation.feature
+++ b/features/200_Correlation.feature
@@ -3,14 +3,14 @@ Feature: Correlation testing
   # Firing Test scenarios
   Scenario: Push data and test correlation alerts for CPU_LINA_THRESHOLD_BREACH
     Given the insights are cleared
-    Then push timeseries for next 60 minutes of which send last 2 minute(s) of timeseries in live mode
+    Then push timeseries for next 60 minutes of which send last 6 minute(s) of timeseries in live mode
       | metric_name            | label_values                              | start_value | end_value | start_spike_minute | spike_duration_minutes |
-      | cpu                    | cpu=lina_dp_avg                           | 5           | 85        | 1                  | 60                     |
-      | cpu                    | cpu=lina_cp_avg                           | 12          | 90        | 1                  | 60                     |
-      | conn_stats             | conn_stats=connection, description=in_use | 12          | 90        | 1                  | 60                     |
-      | interface              | description=input_bytes , interface=all   | 12          | 12        | 1                  | 60                     |
-      | interface              | description=input_packets, interface=all  | 12          | 90        | 1                  | 60                     |
-      | deployed_configuration | deployed_configuration=number_of_ACEs     | 12          | 90        | 1                  | 60                     |
+      | cpu                    | cpu=lina_dp_avg                           | 5           | 85        | 1                  | 55                     |
+      | cpu                    | cpu=lina_cp_avg                           | 12          | 90        | 1                  | 55                     |
+      | conn_stats             | conn_stats=connection, description=in_use | 12          | 90        | 1                  | 55                     |
+      | interface              | description=input_bytes , interface=all   | 12          | 12        | 1                  | 55                     |
+      | interface              | description=input_packets, interface=all  | 12          | 90        | 1                  | 55                     |
+      | deployed_configuration | deployed_configuration=number_of_ACEs     | 12          | 90        | 1                  | 55                     |
     Then keep checking for 10 minute(s) if an CPU_LINA_THRESHOLD_BREACH insight with state ACTIVE is created
     Then push timeseries for next 2 minutes of which send last 2 minute(s) of timeseries in live mode
       | metric_name | label_values    | start_value | end_value | start_spike_minute | spike_duration_minutes |
@@ -19,15 +19,15 @@ Feature: Correlation testing
 
   Scenario: Push data and test correlation alerts for CPU_SNORT_THRESHOLD_BREACH
     Given the insights are cleared
-    Then push timeseries for next 60 minutes of which send last 2 minute(s) of timeseries in live mode
+    Then push timeseries for next 60 minutes of which send last 6 minute(s) of timeseries in live mode
       | metric_name | label_values                                     | start_value | end_value | start_spike_minute | spike_duration_minutes |
-      | cpu         | cpu=snort_avg                                    | 5           | 85        | 1                  | 60                     |
-      | cpu         | cpu=lina_cp_avg                                  | 60          | 90        | 1                  | 60                     |
-      | conn_stats  | conn_stats=connection, description=in_use        | 12          | 90        | 1                  | 60                     |
-      | interface   | description=input_bytes , interface=all          | 12          | 12        | 1                  | 60                     |
-      | interface   | description=input_packets, interface=all         | 12          | 90        | 1                  | 60                     |
-      | interface   | description=input_avg_packet_size, interface=all | 12          | 90        | 1                  | 60                     |
-      | snort       | description=denied_flow_events, snort=stats      | 12          | 90        | 1                  | 60                     |
+      | cpu         | cpu=snort_avg                                    | 5           | 85        | 1                  | 55                     |
+      | cpu         | cpu=lina_cp_avg                                  | 60          | 90        | 1                  | 55                     |
+      | conn_stats  | conn_stats=connection, description=in_use        | 12          | 90        | 1                  | 55                     |
+      | interface   | description=input_bytes , interface=all          | 12          | 12        | 1                  | 55                     |
+      | interface   | description=input_packets, interface=all         | 12          | 90        | 1                  | 55                     |
+      | interface   | description=input_avg_packet_size, interface=all | 12          | 90        | 1                  | 55                     |
+      | snort       | description=denied_flow_events, snort=stats      | 12          | 90        | 1                  | 55                     |
     Then keep checking for 10 minute(s) if an CPU_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created
     Then push timeseries for next 2 minutes of which send last 2 minute(s) of timeseries in live mode
       | metric_name | label_values  | start_value | end_value | start_spike_minute | spike_duration_minutes |
@@ -36,13 +36,13 @@ Feature: Correlation testing
 
   Scenario: Push data and test correlation alerts for MEMORY_LINA_THRESHOLD_BREACH
     Given the insights are cleared
-    Then push timeseries for next 60 minutes of which send last 2 minute(s) of timeseries in live mode
+    Then push timeseries for next 60 minutes of which send last 6 minute(s) of timeseries in live mode
       | metric_name            | label_values                              | start_value | end_value | start_spike_minute | spike_duration_minutes |
-      | mem                    | mem=used_percentage_lina                  | 5           | 85        | 1                  | 60                     |
-      | conn_stats             | conn_stats=connection, description=in_use | 12          | 90        | 1                  | 60                     |
-      | interface              | description=input_bytes , interface=all   | 12          | 12        | 1                  | 60                     |
-      | interface              | description=input_packets, interface=all  | 12          | 90        | 1                  | 60                     |
-      | deployed_configuration | deployed_configuration=number_of_ACEs     | 12          | 90        | 1                  | 60                     |
+      | mem                    | mem=used_percentage_lina                  | 5           | 85        | 1                  | 55                     |
+      | conn_stats             | conn_stats=connection, description=in_use | 12          | 90        | 1                  | 55                     |
+      | interface              | description=input_bytes , interface=all   | 12          | 12        | 1                  | 55                     |
+      | interface              | description=input_packets, interface=all  | 12          | 90        | 1                  | 55                     |
+      | deployed_configuration | deployed_configuration=number_of_ACEs     | 12          | 90        | 1                  | 55                     |
     Then keep checking for 10 minute(s) if an MEMORY_LINA_THRESHOLD_BREACH insight with state ACTIVE is created
     Then push timeseries for next 2 minutes of which send last 2 minute(s) of timeseries in live mode
       | metric_name | label_values             | start_value | end_value | start_spike_minute | spike_duration_minutes |
@@ -51,12 +51,12 @@ Feature: Correlation testing
 
   Scenario: Push data and test correlation alerts for MEMORY_SNORT_THRESHOLD_BREACH
     Given the insights are cleared
-    Then push timeseries for next 60 minutes of which send last 2 minute(s) of timeseries in live mode
+    Then push timeseries for next 60 minutes of which send last 6 minute(s) of timeseries in live mode
       | metric_name | label_values                              | start_value | end_value | start_spike_minute | spike_duration_minutes |
-      | mem         | mem=used_percentage_snort                 | 5           | 85        | 1                  | 60                     |
-      | conn_stats  | conn_stats=connection, description=in_use | 12          | 90        | 1                  | 60                     |
-      | interface   | description=input_bytes , interface=all   | 12          | 12        | 1                  | 60                     |
-      | interface   | description=input_packets, interface=all  | 12          | 90        | 1                  | 60                     |
+      | mem         | mem=used_percentage_snort                 | 5           | 85        | 1                  | 55                     |
+      | conn_stats  | conn_stats=connection, description=in_use | 12          | 90        | 1                  | 55                     |
+      | interface   | description=input_bytes , interface=all   | 12          | 12        | 1                  | 55                     |
+      | interface   | description=input_packets, interface=all  | 12          | 90        | 1                  | 55                     |
     Then keep checking for 10 minute(s) if an MEMORY_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created
     Then push timeseries for next 2 minutes of which send last 2 minute(s) of timeseries in live mode
       | metric_name | label_values              | start_value | end_value | start_spike_minute | spike_duration_minutes |

--- a/features/steps/metrics.py
+++ b/features/steps/metrics.py
@@ -38,8 +38,9 @@ def batch_remote_write(synthesized_ts: Dict[str, Any], step: timedelta):
     labels = synthesized_ts["labels"]
 
     data_points = []
+    current_time = time.time_ns()
     for i, value in enumerate(values):
-        timestamp = int(time.time_ns() - len(values) * step.total_seconds() * 1e9 + i * step.total_seconds() * 1e9)
+        timestamp = int(current_time - len(values) * step.total_seconds() * 1e9 + i * step.total_seconds() * 1e9)
         data_points.append(NumberDataPoint(
             time_unix_nano=timestamp,
             start_time_unix_nano=timestamp,


### PR DESCRIPTION
Description: 

Fixing the timing issue in data ingestion due to which we where getting firing and resolved at the same time 

Succesfull Run:
```
Feature: Correlation testing # features/200_Correlation.feature:1

  Scenario: Push data and test correlation alerts for MEMORY_LINA_THRESHOLD_BREACH                                # features/200_Correlation.feature:37
    Given the insights are cleared                                                                                # features/steps/common_steps.py:8 0.309s
    Then push timeseries for next 60 minutes of which send last 6 minute(s) of timeseries in live mode            # features/steps/correlation.py:14 380.467s
      | metric_name            | label_values                              | start_value | end_value | start_spike_minute | spike_duration_minutes |
      | mem                    | mem=used_percentage_lina                  | 5           | 85        | 1                  | 55                     |
      | conn_stats             | conn_stats=connection, description=in_use | 12          | 90        | 1                  | 55                     |
      | interface              | description=input_bytes , interface=all   | 12          | 12        | 1                  | 55                     |
      | interface              | description=input_packets, interface=all  | 12          | 90        | 1                  | 55                     |
      | deployed_configuration | deployed_configuration=number_of_ACEs     | 12          | 90        | 1                  | 55                     |
    Then keep checking for 10 minute(s) if an MEMORY_LINA_THRESHOLD_BREACH insight with state ACTIVE is created   # features/steps/common_steps.py:28 61.246s
    Then push timeseries for next 2 minutes of which send last 2 minute(s) of timeseries in live mode             # features/steps/correlation.py:14 121.665s
      | metric_name | label_values             | start_value | end_value | start_spike_minute | spike_duration_minutes |
      | mem         | mem=used_percentage_lina | 60          | 60        | 0                  | 1                      |
    Then keep checking for 10 minute(s) if an MEMORY_LINA_THRESHOLD_BREACH insight with state RESOLVED is created 
```