### PR TITLE
Fix insight delete step with parallel execution

### DIFF
--- a/features/000_Onboard.feature
+++ b/features/000_Onboard.feature
@@ -11,3 +11,7 @@ Feature: Onboard and Offboard testing
     Given the tenant onboard state is NOT_ONBOARDED
     When perform a tenant onboard
     Then verify if the onboard status changes to ONBOARDED with a timeout of 5 minute(s)
+
+  Scenario: No Insights Present
+    Given the insights are cleared
+    Then verify no insight is present with a timeout of 2 minute(s)

--- a/features/environment.py
+++ b/features/environment.py
@@ -44,9 +44,6 @@ def before_all(context):
     # Get the remote write config for GCM
     context.remote_write_config = get_gcm_remote_write_config()
 
-    # delete older insights if present
-    delete_insights()
-
 def update_device_details(context):
     # Get cdFMC UID
     resp = get(get_endpoints().FMC_DETAILS_URL, print_body=False)

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -3,7 +3,7 @@ import time
 from behave import *
 from hamcrest import assert_that
 from features.steps.metrics import batch_remote_write
-from features.steps.cdo_apis import delete_insights, verify_insight_type_and_state
+from features.steps.cdo_apis import delete_insights, verify_insight_type_and_state , get_insights
 from datetime import timedelta
 from features.steps.metrics import instant_remote_write
 from features.steps.utils import generate_synthesized_ts_obj, split_data_for_batch_and_live_ingestion
@@ -23,6 +23,16 @@ def step_impl(context, insight_type, insight_state):
 def step_impl(context, insight_type, insight_state, timeout):
     for i in range(int(timeout)):
         if verify_insight_type_and_state(context, insight_type, insight_state):
+            assert_that(True)
+            return
+        time.sleep(60)
+    assert_that(False)
+
+@step('verify no insight is present with a timeout of {timeout} minute(s)')
+def step_impl(context, timeout):
+    for i in range(int(timeout)):
+        insights = get_insights()
+        if insights['count'] == 0:
             assert_that(True)
             return
         time.sleep(60)


### PR DESCRIPTION
Moving the delete step in before_all as before_all hook is called each time a stage is run . Eventually removing the insight over which verification steps are running . 

Moving the insight remove to onboard stage as this is the only stage that runs synchronously before all parallel stages