### PR TITLE
E2E changes and fixes

### DIFF
--- a/features/200_Correlation.feature
+++ b/features/200_Correlation.feature
@@ -73,10 +73,10 @@ Feature: Correlation testing
       | conn_stats  | conn_stats=connection, description=in_use | 12          | 90        | 1                  | 55                     |
       | interface   | description=input_bytes , interface=all   | 12          | 12        | 1                  | 55                     |
       | interface   | description=input_packets, interface=all  | 12          | 90        | 1                  | 55                     |
+    Then verify if an MEMORY_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
     Then confirm correlated metrics
       | metric_name                 | confidence        | 
       | Connections                 | HIGH              | 
-    Then verify if an MEMORY_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
     Then push timeseries for 2 minute(s) of which send last 2 minute(s) of timeseries in live mode
       | metric_name | label_values              | start_value | end_value | start_spike_minute | spike_duration_minutes |
       | mem         | mem=used_percentage_snort | 60          | 60        | 0                  | 1                      |

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -88,7 +88,7 @@ def find_device_available_for_data_ingestion(available_devices:list ,  query:str
     raise("No device available for ingestion")
 
 
-def is_data_not_present(query:str , duration:timedelta):
+def is_data_not_present(query:str , duration:timedelta , step="5m"):
     # Calculate the start and end times
     start_time = datetime.now() - duration
     end_time = datetime.now() 
@@ -97,7 +97,7 @@ def is_data_not_present(query:str , duration:timedelta):
     start_time_epoch = int(start_time.timestamp())
     end_time_epoch = int(end_time.timestamp())
 
-    endpoint = f"{get_endpoints().PROMETHEUS_RANGE_QUERY_URL}?{query}&start={start_time_epoch}&end={end_time_epoch}&step=5m"
+    endpoint = f"{get_endpoints().PROMETHEUS_RANGE_QUERY_URL}?{query}&start={start_time_epoch}&end={end_time_epoch}&step={step}"
     print(endpoint)
     response = get(endpoint, print_body=False)
     if len(response["data"]["result"]) > 0:


### PR DESCRIPTION

Description 

1)Fixing correlation data check issue for memory snort 
2)Changing device selection logic for ra-vpn . We will pick a device for which data is present in the last 365 days instead of pushing data for a new device in each test run . The change is done since ra-vpn runs against all device for which data is available in the last 365 days . 
