### PR TITLE
Adding @wip functionality

### DIFF
--- a/behave.ini
+++ b/behave.ini
@@ -1,0 +1,2 @@
+[behave]
+tags = ~@wip


### PR DESCRIPTION
This PR adds `@wip` functionality. 

Tagging a feature/scenario as `@wip` will skip running that feature/scenario respectively.

This is useful during development and also for adhoc skipping of a feature/scenario.