### PR TITLE
Adding a non-continuous spiky scenario for connection stats anomaly

### DIFF
--- a/features/model.py
+++ b/features/model.py
@@ -30,6 +30,9 @@ class ScenarioEnum(str, Enum):
     ANOMALY_CONNECTION = (
         "Testing Anomaly Detection for Connection Stats With Simple Linear Spike"
     )
+    ANOMALY_CONNECTION_INTERMITTENT_SPIKES = (
+        "Connection stats anomaly with intermittent spikes"
+    )
     ANOMALY_THROUGHPUT = (
         "Testing Anomaly Detection for Throughput Stats With Simple Linear Spike"
     )

--- a/features/steps/anomaly.py
+++ b/features/steps/anomaly.py
@@ -54,7 +54,6 @@ def step_impl(context, duration):
                 duration=timedelta(minutes=int(duration)),
                 start_value=200,
                 end_value=200,
-                step=timedelta(minutes=1),
             ),
             transition_config=TransitionConfig(
                 start_time=now,

--- a/features/steps/anomaly.py
+++ b/features/steps/anomaly.py
@@ -1,9 +1,20 @@
 import time
 from behave import *
 from hamcrest import assert_that
+from mockseries.transition import LinearTransition
+
 from features.model import Device
-from datetime import timedelta
-from features.steps.utils import is_data_present
+from datetime import timedelta, datetime
+
+from features.steps.metrics import instant_remote_write
+from features.steps.time_series_generator import (
+    generate_timeseries,
+    TimeConfig,
+    SeriesConfig,
+    TransitionConfig,
+    generate_spikes,
+)
+from features.steps.utils import is_data_present, get_common_labels
 
 
 def is_anomaly_upper_lower_bounds_present(
@@ -28,3 +39,40 @@ def step_impl(context, metric_name, duration):
             return
         time.sleep(60)
     assert_that(False)
+
+
+@step("push data that is intermittently anomalous for {duration} minute(s)")
+def step_impl(context, duration):
+    labels = {"conn_stats": "connection", "description": "in_use"} | get_common_labels(
+        context, timedelta(days=14)
+    )
+    now = datetime.now()
+    live_data = generate_timeseries(
+        time_config=TimeConfig(
+            series_config=SeriesConfig(
+                start_time=now,
+                duration=timedelta(minutes=int(duration)),
+                start_value=200,
+                end_value=200,
+                step=timedelta(minutes=1),
+            ),
+            transition_config=TransitionConfig(
+                start_time=now,
+                transition=LinearTransition(
+                    transition_window=timedelta(minutes=int(duration)),
+                ),
+            ),
+        ),
+    )
+
+    live_data["y"] = generate_spikes(
+        spike_pattern=[0, 1, 1, 0, 0], spike_multiplier=5, ts_values=live_data["y"]
+    )
+
+    live_data_list = live_data["y"].tolist()
+
+    for i in range(int(duration)):
+        instant_remote_write("conn_stats", labels, live_data_list[i])
+        time.sleep(60)
+
+    pass

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -61,6 +61,18 @@ def step_impl(context, insight_type, insight_state, timeout):
     assert_that(False)
 
 
+@step(
+    "verify if an {insight_type} insight with state {insight_state} is not created with a timeout of {timeout} minute(s)"
+)
+def step_impl(context, insight_type, insight_state, timeout):
+    for i in range(int(timeout)):
+        if verify_insight_type_and_state(context, insight_type, insight_state):
+            assert_that(False)
+            return
+        time.sleep(60)
+    assert_that(True)
+
+
 @step("verify no insight is present with a timeout of {timeout} minute(s)")
 def step_impl(context, timeout):
     for i in range(int(timeout)):

--- a/features/steps/time_series_generator.py
+++ b/features/steps/time_series_generator.py
@@ -149,3 +149,12 @@ def generate_timeseries(
                     ts_values[start_index + i] = None
 
     return convert_to_dataframe(ts_values, time_points)
+
+
+def generate_spikes(spike_pattern, spike_multiplier, ts_values):
+    # Cycle through the spike pattern
+    for i in range(len(ts_values)):
+        if spike_pattern[i % len(spike_pattern)]:
+            ts_values[i] = ts_values[i] * spike_multiplier
+
+    return ts_values

--- a/features/steps/time_series_generator.py
+++ b/features/steps/time_series_generator.py
@@ -155,6 +155,6 @@ def generate_spikes(spike_pattern, spike_multiplier, ts_values):
     # Cycle through the spike pattern
     for i in range(len(ts_values)):
         if spike_pattern[i % len(spike_pattern)]:
-            ts_values[i] = ts_values[i] * spike_multiplier
+            ts_values[i] *= spike_multiplier
 
     return ts_values

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -108,7 +108,10 @@ def get_appropriate_device(context, duration) -> Device:
                 device for device in context.devices if device.ra_vpn_enabled == True
             ]
             query = 'query=vpn{{uuid="{uuid}"}}'
-        case ScenarioEnum.ANOMALY_CONNECTION:
+        case (
+            ScenarioEnum.ANOMALY_CONNECTION
+            | ScenarioEnum.ANOMALY_CONNECTION_INTERMITTENT_SPIKES
+        ):
             query = 'query=conn_stats{{uuid="{uuid}"}}'
         case ScenarioEnum.ANOMALY_THROUGHPUT:
             query = 'query=interface{{interface="all", description="input_bytes", uuid="{uuid}"}} or interface{{interface="all", description="output_bytes", uuid="{uuid}"}}'

--- a/poetry.lock
+++ b/poetry.lock
@@ -2501,32 +2501,25 @@ files = [
 
 [[package]]
 name = "psutil"
-version = "6.1.1"
-description = "Cross-platform lib for process and system monitoring in Python."
+version = "7.0.0"
+description = "Cross-platform lib for process and system monitoring in Python.  NOTE: the syntax of this script MUST be kept compatible with Python 2.7."
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.6"
 files = [
-    {file = "psutil-6.1.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:9ccc4316f24409159897799b83004cb1e24f9819b0dcf9c0b68bdcb6cefee6a8"},
-    {file = "psutil-6.1.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ca9609c77ea3b8481ab005da74ed894035936223422dc591d6772b147421f777"},
-    {file = "psutil-6.1.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:8df0178ba8a9e5bc84fed9cfa61d54601b371fbec5c8eebad27575f1e105c0d4"},
-    {file = "psutil-6.1.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:1924e659d6c19c647e763e78670a05dbb7feaf44a0e9c94bf9e14dfc6ba50468"},
-    {file = "psutil-6.1.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:018aeae2af92d943fdf1da6b58665124897cfc94faa2ca92098838f83e1b1bca"},
-    {file = "psutil-6.1.1-cp27-none-win32.whl", hash = "sha256:6d4281f5bbca041e2292be3380ec56a9413b790579b8e593b1784499d0005dac"},
-    {file = "psutil-6.1.1-cp27-none-win_amd64.whl", hash = "sha256:c777eb75bb33c47377c9af68f30e9f11bc78e0f07fbf907be4a5d70b2fe5f030"},
-    {file = "psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8"},
-    {file = "psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377"},
-    {file = "psutil-6.1.1-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6e06c20c05fe95a3d7302d74e7097756d4ba1247975ad6905441ae1b5b66003"},
-    {file = "psutil-6.1.1-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97f7cb9921fbec4904f522d972f0c0e1f4fabbdd4e0287813b21215074a0f160"},
-    {file = "psutil-6.1.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33431e84fee02bc84ea36d9e2c4a6d395d479c9dd9bba2376c1f6ee8f3a4e0b3"},
-    {file = "psutil-6.1.1-cp36-cp36m-win32.whl", hash = "sha256:384636b1a64b47814437d1173be1427a7c83681b17a450bfc309a1953e329603"},
-    {file = "psutil-6.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8be07491f6ebe1a693f17d4f11e69d0dc1811fa082736500f649f79df7735303"},
-    {file = "psutil-6.1.1-cp37-abi3-win32.whl", hash = "sha256:eaa912e0b11848c4d9279a93d7e2783df352b082f40111e078388701fd479e53"},
-    {file = "psutil-6.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:f35cfccb065fff93529d2afb4a2e89e363fe63ca1e4a5da22b603a85833c2649"},
-    {file = "psutil-6.1.1.tar.gz", hash = "sha256:cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5"},
+    {file = "psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25"},
+    {file = "psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34"},
+    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993"},
+    {file = "psutil-7.0.0-cp36-cp36m-win32.whl", hash = "sha256:84df4eb63e16849689f76b1ffcb36db7b8de703d1bc1fe41773db487621b6c17"},
+    {file = "psutil-7.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:1e744154a6580bc968a0195fd25e80432d3afec619daf145b9e5ba16cc1d688e"},
+    {file = "psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99"},
+    {file = "psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553"},
+    {file = "psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456"},
 ]
 
 [package.extras]
-dev = ["abi3audit", "black", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest-cov", "requests", "rstcheck", "ruff", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
+dev = ["abi3audit", "black (==24.10.0)", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest", "pytest-cov", "pytest-xdist", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
 test = ["pytest", "pytest-xdist", "setuptools"]
 
 [[package]]


### PR DESCRIPTION
This PR adds a scenario where the `conn_stats` anomaly use-case is tested for non-continuous spikes.

This basically tests the `for` condition.

<img width="2055" alt="image" src="https://github.com/user-attachments/assets/9b6320a8-ff02-417c-8d5c-3360d77adac0" />

The peaks are where the alerts will be fired. The backend should ignore these alerts since they are non-continuous spikes.
