### PR TITLE
Batch Backfill 

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -39,6 +39,9 @@ def before_all(context):
     # Initialize map between a scenario and a device (each scenario can have an associated device)
     context.scenario_to_device_map = {}
 
+    # Initialize list of generated data for each scenario for bulk backfill in scenario
+    context.generated_data_list = []
+
     # Get the remote write config for GCM
     context.remote_write_config = get_gcm_remote_write_config()
 


### PR DESCRIPTION
Adding batch backfill support to reduce backfill time as the scenarios increase . As of now one scenario backfill takes 2 hours , hence if it is done sequentially the backfill time will take too long . Batch backfill should resolve this issue 

The step will be integrated once the normla backfill is stabilized in E2E tests 

Scenario Sample Post integration :

```
  
  Scenario: Backfill the data 
      Then prepare backfill metrics for ANOMALY_CONNECTION for a suitable device over 792 hour(s)
        | metric_name            | label_values                              | start_value | end_value | start_spike_minute | spike_duration_minutes | seasonality_period_hours | amplitude |
        | conn_stats             | conn_stats=connection, description=in_use | 15          | 200       | 0                  | 47520                  | 6                        | 2         |
      Then prepare backfill metrics for ANOMALY_THROUGHPUT for a suitable device over 792 hour(s)
        | metric_name            | label_values                              | metric_type        |   start_value | end_value | start_spike_minute       | spike_duration_minutes     | seasonality_period_hours   | amplitude |
        | interface              | interface=all, description=input_bytes    | counter            |   55500          | 106500       | 0                  | 47520                      | 12                         |  8000     |
        | interface              | interface=all, description=output_bytes   | counter            |   55500          | 106500       | 0                  | 47520                      | 12                         |  8000     |
      Then start backfill
  
```
