### PR TITLE
Adding POST call to forecast app to ensure device data is present

### DIFF
--- a/features/steps/cdo_apis.py
+++ b/features/steps/cdo_apis.py
@@ -71,6 +71,12 @@ def get_onboard_status():
     return get(endpoints.TENANT_STATUS_URL, print_body=True)
 
 
+def update_device_data(device_uid):
+    print(f"Updating device data for {device_uid} to have 250 max sessions")
+    payload = {"device_uid": device_uid, "max_vpn_sessions": 250}
+    return post(endpoints.FORECAST_DEVICE_DATA_URL, json.dumps(payload), 201)
+
+
 def get(endpoint, print_body=True):
     try:
         print(f"Sending GET request to {endpoint}")

--- a/features/steps/env.py
+++ b/features/steps/env.py
@@ -55,6 +55,9 @@ class Endpoints:
         self.MODULE_SETTINGS_ENDPOINT = (
             self.BASE_URL + "/api/platform/ai-ops-orchestrator/v1/settings/module"
         )
+        self.FORECAST_DEVICE_DATA_URL = (
+            self.BASE_URL + "/api/platform/ai-ops-forecast/v1/device_data"
+        )
 
 
 def get_endpoints():

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -7,7 +7,7 @@ from mockseries.transition import LinearTransition
 from pydantic import BaseModel
 from features.model import ScenarioEnum, Device
 from features.steps.env import get_endpoints
-from features.steps.cdo_apis import get
+from features.steps.cdo_apis import get, update_device_data
 from features.steps.time_series_generator import (
     generate_timeseries,
     TimeConfig,
@@ -65,6 +65,8 @@ def get_common_labels(context, duration: timedelta):
     else:
         device = get_appropriate_device(context, duration)
         print("Selected device: ", device)
+        if context.scenario == ScenarioEnum.RAVPN_FORECAST:
+            update_device_data(device.aegis_device_uid)
         context.scenario_to_device_map[context.scenario] = device
 
     return {"tenant_uuid": context.tenant_id, "uuid": device.device_record_uid}


### PR DESCRIPTION
This PR ensures that once a device is selected for RA-VPN scenario, the `DeviceData` is populated for the respective device. This ensures the forecasting pipeline doesn't fail. 