### PR TITLE
correlation ha/cluster test cases

### DIFF
--- a/features/200_Correlation.feature
+++ b/features/200_Correlation.feature
@@ -34,8 +34,8 @@ Feature: Correlation testing
       | interface              | description=input_packets, interface=all         | 12          | 90        | 1                  | 55                     |
       | interface              | description=input_avg_packet_size, interface=all | 12          | 90        | 1                  | 55                     |
       | snort                  | description=denied_flow_events, snort=stats      | 12          | 90        | 1                  | 55                     |
-      | snort3_perfstats       | snort3_perfstats="concurrent_elephant_flows"     | 12          | 90        | 1                  | 55                     |
-      | asp_drops              | asp_drops="snort-busy-not-fp"                    | 12          | 90        | 1                  | 55                     |
+      | snort3_perfstats       | snort3_perfstats=concurrent_elephant_flows       | 12          | 90        | 1                  | 55                     |
+      | asp_drops              | asp_drops=snort-busy-not-fp                      | 12          | 90        | 1                  | 55                     |
     Then verify if an CPU_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
     Then confirm correlated metrics
       | metric_name                 | confidence        | 
@@ -81,3 +81,97 @@ Feature: Correlation testing
       | metric_name | label_values              | start_value | end_value | start_spike_minute | spike_duration_minutes |
       | mem         | mem=used_percentage_snort | 60          | 60        | 0                  | 1                      |
     Then verify if an MEMORY_SNORT_THRESHOLD_BREACH insight with state RESOLVED is created with a timeout of 10 minute(s)
+
+  Scenario: Push data and test multi correlation alerts for HA active device
+    Then push timeseries for 60 minute(s) of which send last 6 minute(s) of timeseries in live mode
+      | metric_name            | label_values                                     | start_value | end_value | start_spike_minute | spike_duration_minutes |
+      | cpu                    | cpu=lina_dp_avg                                  | 5           | 85        | 1                  | 55                     |
+      | cpu                    | cpu=snort_avg                                    | 5           | 85        | 1                  | 55                     |
+      | cpu                    | cpu=lina_cp_avg                                  | 12          | 90        | 1                  | 55                     |
+      | mem                    | mem=used_percentage_lina                         | 5           | 85        | 1                  | 55                     |
+      | mem                    | mem=used_percentage_snort                        | 5           | 85        | 1                  | 55                     |
+      | conn_stats             | conn_stats=connection, description=in_use        | 12          | 90        | 1                  | 55                     |
+      | interface              | description=input_bytes , interface=all          | 12          | 12        | 1                  | 55                     |
+      | interface              | description=input_packets, interface=all         | 12          | 90        | 1                  | 55                     |
+      | interface              | description=input_avg_packet_size, interface=all | 12          | 90        | 1                  | 55                     |
+      | interface              | description=drop_packets                         | 12          | 90        | 1                  | 55                     |
+      | deployed_configuration | deployed_configuration=number_of_ACEs            | 12          | 90        | 1                  | 55                     |
+      | snort                  | description=denied_flow_events, snort=stats      | 12          | 90        | 1                  | 55                     |
+      | snort3_perfstats       | snort3_perfstats=concurrent_elephant_flows       | 12          | 90        | 1                  | 55                     |
+      | asp_drops              | asp_drops=snort-busy-not-fp                      | 12          | 90        | 1                  | 55                     |
+    Then verify if an CPU_LINA_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
+    Then confirm correlated metrics
+      | metric_name                 | confidence        | 
+      | Control plane CPU           | HIGH              | 
+      | Connections                 | HIGH              | 
+      | Deployed ACE Configurations | HIGH              | 
+    Then verify if an CPU_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
+    Then confirm correlated metrics
+      | metric_name                 | confidence        | 
+      | Input Packet Size           | HIGH              | 
+      | Snort Denied Flows          | HIGH              | 
+      | Connections                 | HIGH              |
+      | Control plane CPU           | HIGH              |
+    Then verify if an MEMORY_LINA_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
+    Then confirm correlated metrics
+      | metric_name                 | confidence        | 
+      | Connections                 | HIGH              | 
+      | Deployed ACE Configurations | HIGH             | 
+    Then verify if an MEMORY_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
+    Then confirm correlated metrics
+      | metric_name                 | confidence        | 
+      | Connections                 | HIGH              | 
+    Then push timeseries for 2 minute(s) of which send last 2 minute(s) of timeseries in live mode
+      | metric_name | label_values                  | start_value | end_value | start_spike_minute  | spike_duration_minutes |
+      | cpu         | cpu=lina_dp_avg               | 60          | 60        | 0                   | 1                      |
+      | cpu         | cpu=snort_avg                 | 60          | 60        | 0                   | 1                      |
+      | mem         | mem=used_percentage_lina      | 60          | 60        | 0                   | 1                      |
+      | mem         | mem=used_percentage_snort     | 60          | 60        | 0                   | 1                      |
+    Then verify if an CPU_LINA_THRESHOLD_BREACH insight with state RESOLVED is created with a timeout of 10 minute(s)
+
+  Scenario: Push data and test multi correlation alerts for CLUSTER control device
+    Then push timeseries for 60 minute(s) of which send last 6 minute(s) of timeseries in live mode
+      | metric_name            | label_values                                     | start_value | end_value | start_spike_minute | spike_duration_minutes |
+      | cpu                    | cpu=lina_dp_avg                                  | 5           | 85        | 1                  | 55                     |
+      | cpu                    | cpu=snort_avg                                    | 5           | 85        | 1                  | 55                     |
+      | cpu                    | cpu=lina_cp_avg                                  | 12          | 90        | 1                  | 55                     |
+      | mem                    | mem=used_percentage_lina                         | 5           | 85        | 1                  | 55                     |
+      | mem                    | mem=used_percentage_snort                        | 5           | 85        | 1                  | 55                     |
+      | conn_stats             | conn_stats=connection, description=in_use        | 12          | 90        | 1                  | 55                     |
+      | interface              | description=input_bytes , interface=all          | 12          | 12        | 1                  | 55                     |
+      | interface              | description=input_packets, interface=all         | 12          | 90        | 1                  | 55                     |
+      | interface              | description=input_avg_packet_size, interface=all | 12          | 90        | 1                  | 55                     |
+      | interface              | description=drop_packets                         | 12          | 90        | 1                  | 55                     |
+      | deployed_configuration | deployed_configuration=number_of_ACEs            | 12          | 90        | 1                  | 55                     |
+      | snort                  | description=denied_flow_events, snort=stats      | 12          | 90        | 1                  | 55                     |
+      | snort3_perfstats       | snort3_perfstats=concurrent_elephant_flows       | 12          | 90        | 1                  | 55                     |
+      | asp_drops              | asp_drops=snort-busy-not-fp                      | 12          | 90        | 1                  | 55                     |
+    Then verify if an CPU_LINA_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
+    Then confirm correlated metrics
+      | metric_name                 | confidence        | 
+      | Control plane CPU           | HIGH              | 
+      | Connections                 | HIGH              | 
+      | Deployed ACE Configurations | HIGH              | 
+    Then verify if an CPU_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
+    Then confirm correlated metrics
+      | metric_name                 | confidence        | 
+      | Input Packet Size           | HIGH              | 
+      | Snort Denied Flows          | HIGH              | 
+      | Connections                 | HIGH              |
+      | Control plane CPU           | HIGH              |
+    Then verify if an MEMORY_LINA_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
+    Then confirm correlated metrics
+      | metric_name                 | confidence        | 
+      | Connections                 | HIGH              | 
+      | Deployed ACE Configurations | HIGH             | 
+    Then verify if an MEMORY_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)
+    Then confirm correlated metrics
+      | metric_name                 | confidence        | 
+      | Connections                 | HIGH              | 
+    Then push timeseries for 2 minute(s) of which send last 2 minute(s) of timeseries in live mode
+      | metric_name | label_values                  | start_value | end_value | start_spike_minute  | spike_duration_minutes |
+      | cpu         | cpu=lina_dp_avg               | 60          | 60        | 0                   | 1                      |
+      | cpu         | cpu=snort_avg                 | 60          | 60        | 0                   | 1                      |
+      | mem         | mem=used_percentage_lina      | 60          | 60        | 0                   | 1                      |
+      | mem         | mem=used_percentage_snort     | 60          | 60        | 0                   | 1                      |
+    Then verify if an CPU_LINA_THRESHOLD_BREACH insight with state RESOLVED is created with a timeout of 10 minute(s)

--- a/features/environment.py
+++ b/features/environment.py
@@ -24,7 +24,6 @@ def before_all(context):
     load_dotenv()
     cdo_token = os.getenv("CDO_TOKEN")
     os.environ["CDO_TOKEN"] = cdo_token
-
     # Adding the tenant_id to the context
     if cdo_token != "" and cdo_token is not None:
         decoded = jwt.decode(cdo_token, options={"verify_signature": False})
@@ -75,12 +74,13 @@ def update_device_details(context):
 
     available_devices = []  # List of all the available devices
     ra_vpn_devices = []  # List of only the devices with RA-VPN enabled
-    device_details = get(get_endpoints().DEVICES_DETAILS_URL, print_body=False)
+    device_details = get(get_endpoints().DEVICES_DETAILS_URL + "&limit=200", print_body=False)
     for device in device_details:
         device_obj = Device(
             device_name=device["name"],
             aegis_device_uid=device["uid"],
             device_record_uid=device["metadata"]["deviceRecordUuid"],
+            container_type=device["metadata"]["containerType"],
         )
         ra_vpn_enabled = False
         if is_ra_vpn_enabled(
@@ -90,7 +90,6 @@ def update_device_details(context):
             ra_vpn_devices.append(device_obj)
         device_obj.ra_vpn_enabled = ra_vpn_enabled
         available_devices.append(device_obj)
-
     context.devices = available_devices
 
     print(

--- a/features/model.py
+++ b/features/model.py
@@ -7,6 +7,7 @@ class Device(BaseModel):
     aegis_device_uid: str
     device_record_uid: str
     ra_vpn_enabled: bool = False
+    container_type: str | None = None
 
 
 class ScenarioEnum(str, Enum):
@@ -19,6 +20,12 @@ class ScenarioEnum(str, Enum):
     )
     CORRELATION_CPU_SNORT = (
         "Push data and test correlation alerts for CPU_SNORT_THRESHOLD_BREACH"
+    )
+    CORRELATION_HA_ACTIVE = (
+        "Push data and test multi correlation alerts for HA active device"
+    )
+    CORRELATION_CLUSTER_CONTROL = (
+        "Push data and test multi correlation alerts for CLUSTER control device"
     )
     CORRELATION_MEM_LINA = (
         "Push data and test correlation alerts for MEMORY_LINA_THRESHOLD_BREACH"

--- a/features/steps/utils.py
+++ b/features/steps/utils.py
@@ -89,22 +89,90 @@ def get_appropriate_device(context, duration) -> Device:
     """
 
     query = ""
-    available_devices = context.devices
+    # Only pickup standalone devices
+    available_devices = [
+                device
+                for device in context.devices
+                if device.container_type == None
+            ]
 
     scenario = context.scenario
     match scenario:
         case ScenarioEnum.ELEPHANTFLOW_ENHANCED | ScenarioEnum.ELEPHANTFLOW_LEGACY:
             query = 'query=efd_cpu_usage{{uuid="{uuid}"}}'
         case ScenarioEnum.CORRELATION_CPU_LINA:
-            query = 'query=cpu{{cpu=~"lina_cp_avg|lina_dp_avg" , uuid="{uuid}"}} or rate(interface{{description=~"input_bytes|input_packets" ,interface="all" , uuid="{uuid}"}}[4m]) or conn_stats{{conn_stats="connection", description="in_use",  uuid="{uuid}"}} or deployed_configuration{{deployed_configuration="number_of_ACEs"  , uuid="{uuid}"}} or sum(rate(interface{{description="drop_packets", uuid="{uuid}"}}[4m])) by (uuid , description)'
+            query = (
+                        'query=cpu{{cpu=~"lina_cp_avg|lina_dp_avg", uuid="{uuid}"}} '
+                        'or rate(interface{{description=~"input_bytes|input_packets", interface="all", uuid="{uuid}"}}[4m]) '
+                        'or conn_stats{{conn_stats="connection", description="in_use", uuid="{uuid}"}} '
+                        'or deployed_configuration{{deployed_configuration="number_of_ACEs", uuid="{uuid}"}} '
+                        'or sum(rate(interface{{description="drop_packets", uuid="{uuid}"}}[4m])) by (uuid, description)'
+                    )
         case ScenarioEnum.CORRELATION_CPU_SNORT:
-            query = 'query=cpu{{cpu=~"snort_avg|lina_cp_avg" , uuid="{uuid}"}} or rate(interface{{description=~"input_bytes|input_packets|input_avg_packet_size" ,interface="all" , uuid="{uuid}"}}[4m]) or conn_stats{{conn_stats="connection", description="in_use",  uuid="{uuid}"}} or snort{{description="denied_flow_events",snort="stats" , uuid="{uuid}"}} or snort3_perfstats{{snort3_perfstats="concurrent_elephant_flows", uuid="{uuid}"}} or rate(asp_drops{{asp_drops="snort-busy-not-fp", uuid="{uuid}"}}[4m])'
+            query = (
+                        'query=cpu{{cpu=~"snort_avg|lina_cp_avg", uuid="{uuid}"}} '
+                        'or rate(interface{{description=~"input_bytes|input_packets|input_avg_packet_size", interface="all", uuid="{uuid}"}}[4m]) '
+                        'or conn_stats{{conn_stats="connection", description="in_use", uuid="{uuid}"}} '
+                        'or snort{{description="denied_flow_events", snort="stats", uuid="{uuid}"}} '
+                        'or snort3_perfstats{{snort3_perfstats="concurrent_elephant_flows", uuid="{uuid}"}} '
+                        'or rate(asp_drops{{asp_drops="snort-busy-not-fp", uuid="{uuid}"}}[4m])'
+                    )
         case ScenarioEnum.CORRELATION_MEM_LINA:
-            query = 'query=mem{{mem="used_percentage_lina", uuid="{uuid}"}} or rate(interface{{description=~"input_bytes|input_packets" ,interface="all" , uuid="{uuid}"}}[4m]) or conn_stats{{conn_stats="connection", description="in_use",  uuid="{uuid}"}} or deployed_configuration{{deployed_configuration="number_of_ACEs"  , uuid="{uuid}"}}'
+            query = (
+                        'query=mem{{mem="used_percentage_lina", uuid="{uuid}"}} '
+                        'or rate(interface{{description=~"input_bytes|input_packets", interface="all", uuid="{uuid}"}}[4m]) '
+                        'or conn_stats{{conn_stats="connection", description="in_use", uuid="{uuid}"}} '
+                        'or deployed_configuration{{deployed_configuration="number_of_ACEs", uuid="{uuid}"}}'
+                    )
         case ScenarioEnum.CORRELATION_MEM_SNORT:
-            query = 'query=mem{{mem="used_percentage_snort", uuid="{uuid}"}} or rate(interface{{description=~"input_bytes|input_packets" ,interface="all" , uuid="{uuid}"}}[4m]) or conn_stats{{conn_stats="connection", description="in_use",  uuid="{uuid}"}}'
+            query = (
+                        'query=mem{{mem="used_percentage_snort", uuid="{uuid}"}} '
+                        'or rate(interface{{description=~"input_bytes|input_packets", interface="all", uuid="{uuid}"}}[4m]) '
+                        'or conn_stats{{conn_stats="connection", description="in_use", uuid="{uuid}"}}'
+                    )
         case ScenarioEnum.CORRELATION_MEM_SNORT:
-            query = 'query=mem{{mem="used_percentage_snort", uuid="{uuid}"}} or rate(interface{{description=~"input_bytes|input_packets" ,interface="all" , uuid="{uuid}"}}[4m]) or conn_stats{{conn_stats="connection", description="in_use",  uuid="{uuid}"}}'
+            query = (
+                        'query=mem{{mem="used_percentage_snort", uuid="{uuid}"}} '
+                        'or rate(interface{{description=~"input_bytes|input_packets", interface="all", uuid="{uuid}"}}[4m]) '
+                        'or conn_stats{{conn_stats="connection", description="in_use", uuid="{uuid}"}}'
+                    )  
+        case ScenarioEnum.CORRELATION_HA_ACTIVE:
+            available_devices = [
+                device
+                for device in context.devices
+                if device.container_type == "HA_PAIR"
+            ]
+
+            query = (
+                        'query=cpu{{cpu=~"lina_cp_avg|snort_avg|lina_dp_avg", uuid="{uuid}"}} '
+                        'or rate(interface{{description=~"input_bytes|input_packets", interface="all", uuid="{uuid}"}}[4m]) '
+                        'or conn_stats{{conn_stats="connection", description="in_use", uuid="{uuid}"}} '
+                        'or deployed_configuration{{deployed_configuration="number_of_ACEs", uuid="{uuid}"}} '
+                        'or sum(rate(interface{{description="drop_packets", uuid="{uuid}"}}[4m])) by (uuid, description) '
+                        'or snort{{description="denied_flow_events", snort="stats", uuid="{uuid}"}} '
+                        'or snort3_perfstats{{snort3_perfstats="concurrent_elephant_flows", uuid="{uuid}"}} '
+                        'or rate(asp_drops{{asp_drops="snort-busy-not-fp", uuid="{uuid}"}}[4m])'
+                        'or mem{{mem="used_percentage_lina", uuid="{uuid}"}} '
+                        'or mem{{mem="used_percentage_snort", uuid="{uuid}"}}'
+                    )
+        case ScenarioEnum.CORRELATION_CLUSTER_CONTROL:
+            available_devices = [
+                device
+                for device in context.devices
+                if device.container_type == "CLUSTER"
+            ]
+            query = (
+                        'query=cpu{{cpu=~"lina_cp_avg|snort_avg|lina_dp_avg", uuid="{uuid}"}} '
+                        'or rate(interface{{description=~"input_bytes|input_packets", interface="all", uuid="{uuid}"}}[4m]) '
+                        'or conn_stats{{conn_stats="connection", description="in_use", uuid="{uuid}"}} '
+                        'or deployed_configuration{{deployed_configuration="number_of_ACEs", uuid="{uuid}"}} '
+                        'or sum(rate(interface{{description="drop_packets", uuid="{uuid}"}}[4m])) by (uuid, description) '
+                        'or snort{{description="denied_flow_events", snort="stats", uuid="{uuid}"}} '
+                        'or snort3_perfstats{{snort3_perfstats="concurrent_elephant_flows", uuid="{uuid}"}} '
+                        'or rate(asp_drops{{asp_drops="snort-busy-not-fp", uuid="{uuid}"}}[4m])'
+                        'or mem{{mem="used_percentage_lina", uuid="{uuid}"}} '
+                        'or mem{{mem="used_percentage_snort", uuid="{uuid}"}}'
+                    )
         case ScenarioEnum.RAVPN_FORECAST:
             available_devices = [
                 device for device in context.devices if device.ra_vpn_enabled == True


### PR DESCRIPTION
Description : 

Adding HA and cluster test cases for correlation feature . Adding HA active and Cluster control node test case which tests all correlation feature per scenario

```
  Background:   # features/200_Correlation.feature:2

  Scenario: Push data and test multi correlation alerts for CLUSTER control device                                      # features/200_Correlation.feature:134
    Given the tenant onboard state is ONBOARDED                                                                         # features/steps/onboard.py:17 0.661s
    Then push timeseries for 60 minute(s) of which send last 6 minute(s) of timeseries in live mode                     # features/steps/common_steps.py:100 473.643s
      | metric_name            | label_values                                     | start_value | end_value | start_spike_minute | spike_duration_minutes |
      | cpu                    | cpu=lina_dp_avg                                  | 5           | 85        | 1                  | 55                     |
      | cpu                    | cpu=snort_avg                                    | 5           | 85        | 1                  | 55                     |
      | cpu                    | cpu=lina_cp_avg                                  | 12          | 90        | 1                  | 55                     |
      | mem                    | mem=used_percentage_lina                         | 5           | 85        | 1                  | 55                     |
      | mem                    | mem=used_percentage_snort                        | 5           | 85        | 1                  | 55                     |
      | conn_stats             | conn_stats=connection, description=in_use        | 12          | 90        | 1                  | 55                     |
      | interface              | description=input_bytes , interface=all          | 12          | 12        | 1                  | 55                     |
      | interface              | description=input_packets, interface=all         | 12          | 90        | 1                  | 55                     |
      | interface              | description=input_avg_packet_size, interface=all | 12          | 90        | 1                  | 55                     |
      | interface              | description=drop_packets                         | 12          | 90        | 1                  | 55                     |
      | deployed_configuration | deployed_configuration=number_of_ACEs            | 12          | 90        | 1                  | 55                     |
      | snort                  | description=denied_flow_events, snort=stats      | 12          | 90        | 1                  | 55                     |
      | snort3_perfstats       | snort3_perfstats=concurrent_elephant_flows       | 12          | 90        | 1                  | 55                     |
      | asp_drops              | asp_drops=snort-busy-not-fp                      | 12          | 90        | 1                  | 55                     |
    Then verify if an CPU_LINA_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)     # features/steps/common_steps.py:55 3.680s
    Then confirm correlated metrics                                                                                     # features/steps/correlation.py:4 0.000s
      | metric_name                 | confidence |
      | Control plane CPU           | HIGH       |
      | Connections                 | HIGH       |
      | Deployed ACE Configurations | HIGH       |
    Then verify if an CPU_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)    # features/steps/common_steps.py:55 2.467s
    Then confirm correlated metrics                                                                                     # features/steps/correlation.py:4 0.000s
      | metric_name        | confidence |
      | Input Packet Size  | HIGH       |
      | Snort Denied Flows | HIGH       |
      | Connections        | HIGH       |
      | Control plane CPU  | HIGH       |
    Then verify if an MEMORY_LINA_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s)  # features/steps/common_steps.py:55 2.374s
    Then confirm correlated metrics                                                                                     # features/steps/correlation.py:4 0.000s
      | metric_name                 | confidence |
      | Connections                 | HIGH       |
      | Deployed ACE Configurations | HIGH       |
    Then verify if an MEMORY_SNORT_THRESHOLD_BREACH insight with state ACTIVE is created with a timeout of 10 minute(s) # features/steps/common_steps.py:55 3.065s
    Then confirm correlated metrics                                                                                     # features/steps/correlation.py:4 0.000s
      | metric_name | confidence |
      | Connections | HIGH       |
    Then push timeseries for 2 minute(s) of which send last 2 minute(s) of timeseries in live mode                      # features/steps/common_steps.py:100 131.531s
      | metric_name | label_values              | start_value | end_value | start_spike_minute | spike_duration_minutes |
      | cpu         | cpu=lina_dp_avg           | 60          | 60        | 0                  | 1                      |
      | cpu         | cpu=snort_avg             | 60          | 60        | 0                  | 1                      |
      | mem         | mem=used_percentage_lina  | 60          | 60        | 0                  | 1                      |
      | mem         | mem=used_percentage_snort | 60          | 60        | 0                  | 1                      |
    Then verify if an CPU_LINA_THRESHOLD_BREACH insight with state RESOLVED is created with a timeout of 10 minute(s)   # features/steps/common_steps.py:55 259.115s
```