### PR TITLE
Adding logger

### DIFF
--- a/features/llm/helios.py
+++ b/features/llm/helios.py
@@ -65,7 +65,7 @@ def ingest_files(kb_id: str, context_dir: str):
         headers=headers,
         files=files,
     ).json()
-    print(response)
+    logging.info(response)
 
 
 def create_thread():

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -3,14 +3,13 @@ import os
 import subprocess
 import time
 from typing import List
+import logging
 
 from behave import *
 from hamcrest import assert_that
 from jinja2 import Template
 
-from features.model import Device
 from features.steps.utils import (
-    BackfillData,
     check_if_data_present,
     convert_to_backfill_data,
 )
@@ -138,7 +137,9 @@ def step_impl(context, duration, live_duration):
 
     # Live data generation
     live_ingest_datapoints_count = len(synthesized_ts_list_for_live_fill[0].values)
-    print(f"Pushing {live_ingest_datapoints_count} datapoints through live ingestion ")
+    logging.info(
+        f"Pushing {live_ingest_datapoints_count} datapoints through live ingestion "
+    )
     for i in range(live_ingest_datapoints_count):
         data_for_current_instant = []
         for value_dict in synthesized_ts_list_for_live_fill:
@@ -296,7 +297,7 @@ def backfill_generated_data(context, generated_data_list: List[GeneratedData]):
 
 def generate_data_for_input(context, duration_delta: timedelta) -> List[GeneratedData]:
     if context.remote_write_config is None:
-        print("Remote write config not found. Skipping backfill.")
+        logging.info("Remote write config not found. Skipping backfill.")
         assert False
 
     generated_data_list: List[GeneratedData] = []

--- a/features/steps/correlation.py
+++ b/features/steps/correlation.py
@@ -1,3 +1,4 @@
+import logging
 from behave import *
 
 
@@ -15,7 +16,7 @@ def step_impl(context):
                 if correlationMetric["correlationRank"] == confidence:
                     return True
 
-        print(
+        logging.error(
             f"Expected correlation metric {metric_name} with confidence {confidence} not found"
         )
         assert False

--- a/features/steps/elephant_flow.py
+++ b/features/steps/elephant_flow.py
@@ -1,6 +1,6 @@
-from features.steps.cdo_apis import get_insights
 from behave import *
 import json
+import logging
 
 
 @step("check elephant flow insight data")
@@ -9,7 +9,7 @@ def step_impl(context):
     expected_flow_data = json.loads(context.text)["flows"]
     expected_length = len(expected_flow_data)
     if len(insight["data"]["flows"]) != expected_length:
-        print(
+        logging.info(
             f"Expected {expected_length} flow but got {len(insight['data']['flows'])}"
         )
         assert False
@@ -20,5 +20,5 @@ def step_impl(context):
         del flow["stats"]
 
     if flows != expected_flow_data:
-        print(f"Expected flow data {expected_flow_data} but got {flow}")
+        logging.error(f"Expected flow data {expected_flow_data} but got {flows}")
         assert False

--- a/features/steps/metrics.py
+++ b/features/steps/metrics.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Dict
+import logging
 from datetime import timedelta
 from behave import *
 from opentelemetry import metrics
@@ -31,7 +31,7 @@ def create_gauge(name: str, description: str):
         name=name,
         description=description,
     )
-    print(f"Created gauge {name} with description {description}")
+    logging.info(f"Created gauge {name} with description {description}")
     active_metrics[name] = gauge
 
 
@@ -89,11 +89,11 @@ def instant_remote_write(metric_name: str, labels: dict[str, str], value: float)
     try:
         remote_write(metrics_data=metrics_data)
     except Exception:
-        print(
+        logging.error(
             f"Failed to export metric {metric_name} with labels {labels} and value {value}"
         )
         return
-    print(
+    logging.info(
         f"Exported metric {metric_name} with labels {labels} and value {value} succesfully"
     )
 

--- a/features/steps/ra_vpn.py
+++ b/features/steps/ra_vpn.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os.path
 import subprocess
 import time
@@ -30,7 +31,7 @@ HISTORICAL_DATA_FILE = "ravpn_historical_data.txt"
 @step("backfill RAVPN metrics for a suitable device")
 def step_impl(context):
     if context.remote_write_config is None:
-        print("Remote write config not found. Skipping backfill.")
+        logging.info("Remote write config not found. Skipping backfill.")
         assert False
 
     # TODO : Remove post checking backfill behaviour for RA-VPN
@@ -79,7 +80,7 @@ def step_impl(context):
         ],
     )
     end_time = time.time()
-    print(f"Backfill took {(end_time - start_time)/60:.2f} minutes")
+    logging.info(f"Backfill took {(end_time - start_time)/60:.2f} minutes")
 
     # Calculate the start and end times
     start_time = datetime.now() - timedelta(days=14)
@@ -98,7 +99,7 @@ def step_impl(context):
     while True:
         # Exit after 60 minutes
         if count > 60:
-            print("Data not ingested in Prometheus. Exiting.")
+            logging.info("Data not ingested in Prometheus. Exiting.")
             break
 
         count += 1
@@ -110,7 +111,7 @@ def step_impl(context):
             num_data_points_inactive_ravpn = len(
                 response["data"]["result"][1]["values"]
             )
-            print(
+            logging.info(
                 f"Active RAVPN data points: {num_data_points_active_ravpn}. Inactive RAVPN data points: {num_data_points_inactive_ravpn}"
             )
             if (
@@ -154,7 +155,9 @@ def is_device_present_with_ra_vpn_data(context):
             query.format(uuid=device.device_record_uid), timedelta(days=365), "60m"
         ):
             context.scenario_to_device_map[context.scenario] = device
-            print("Device with RA-VPN data already present , Selected device: ", device)
+            logging.info(
+                "Device with RA-VPN data already present , Selected device: ", device
+            )
             return True
     return False
 


### PR DESCRIPTION
This PR adds a basic logger that prefixes logs with timestamps in UTC format and the log level.


### Sample output

```bash
Feature: Onboard and Offboard testing # features/000_Onboard.feature:1

  Scenario: Test offboard                                                                    # features/000_Onboard.feature:4
    Given the tenant onboard state is ONBOARDED                                              # features/steps/onboard.py:21
[2025-07-21T11:54:29Z] [INFO] Sending GET request to https://edge.staging.cdo.cisco.com/api/platform/ai-ops-orchestrator/v1/tenant/status
    Given the tenant onboard state is ONBOARDED                                              # features/steps/onboard.py:21 0.763s
    When perform a tenant offboard                                                           # features/steps/onboard.py:13
[2025-07-21T11:54:30Z] [INFO] Sending POST request to https://edge.staging.cdo.cisco.com/api/platform/ai-ops-orchestrator/v1/tenant/offboard with payload {"cleanupType": "SHALLOW"}
    When perform a tenant offboard                                                           # features/steps/onboard.py:13 0.611s
    Then verify if the onboard status changes to NOT_ONBOARDED with a timeout of 2 minute(s) # features/steps/onboard.py:27
[2025-07-21T11:54:31Z] [INFO] Sending GET request to https://edge.staging.cdo.cisco.com/api/platform/ai-ops-orchestrator/v1/tenant/status
[2025-07-21T11:54:31Z] [INFO] Response status: 200, Response: {'onboardState': 'ONBOARDED'}
[2025-07-21T11:54:41Z] [INFO] Sending GET request to https://edge.staging.cdo.cisco.com/api/platform/ai-ops-orchestrator/v1/tenant/status
    Then verify if the onboard status changes to NOT_ONBOARDED with a timeout of 2 minute(s) # features/steps/onboard.py:27 11.112s

```