### PR TITLE
Log level fixes

### DIFF
--- a/features/steps/cdo_apis.py
+++ b/features/steps/cdo_apis.py
@@ -94,7 +94,7 @@ def verify_insight_type_and_state(context, insight_type, state):
                     f"Expected insight type: {insight_type} - state: {state} - device name: {context.scenario_to_device_map[context.scenario].device_name} - device id: {context.scenario_to_device_map[context.scenario].aegis_device_uid}"
                 )
                 logging.debug(f"Actual Insight: {insight}")
-    logging.error(
+    logging.info(
         f"Failed to find an insight with type: {insight_type} and state: {state} for device name: {context.scenario_to_device_map[context.scenario].device_name} and device id: {context.scenario_to_device_map[context.scenario].aegis_device_uid}"
     )
     return False

--- a/features/steps/common_steps.py
+++ b/features/steps/common_steps.py
@@ -48,7 +48,14 @@ def step_impl(context):
 
 @step("verify if an {insight_type} insight with state {insight_state} is created")
 def step_impl(context, insight_type, insight_state):
-    assert_that(verify_insight_type_and_state(context, insight_type, insight_state))
+    verification_status = verify_insight_type_and_state(
+        context, insight_type, insight_state
+    )
+    if not verification_status:
+        logging.error(
+            f"Failed to verify insight of type {insight_type} and state {insight_state}"
+        )
+    assert_that(verification_status)
 
 
 @step(
@@ -60,6 +67,9 @@ def step_impl(context, insight_type, insight_state, timeout):
             assert_that(True)
             return
         time.sleep(60)
+    logging.error(
+        f"Failed to verify insight of type {insight_type} and state {insight_state}"
+    )
     assert_that(False)
 
 
@@ -69,6 +79,9 @@ def step_impl(context, insight_type, insight_state, timeout):
 def step_impl(context, insight_type, insight_state, timeout):
     for i in range(int(timeout)):
         if verify_insight_type_and_state(context, insight_type, insight_state):
+            logging.error(
+                f"Found insight of type {insight_type} and state {insight_state} , when none was expected"
+            )
             assert_that(False)
             return
         time.sleep(60)


### PR DESCRIPTION
Log level fixes for better readability .  Status check failure is not necessarily an error as we expect to see a few failures before it passes . its only a failure if all attempts fail